### PR TITLE
fix(xdebug): xdebug not triggering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: down up db build schema fixtures cache clean
+.PHONY: down up db build schema fixtures cache clean debug
 
 .DEFAULT_GOAL := clean
+
+debug:
+	XDEBUG_MODE=debug docker compose up --pull always -d --wait
 
 fix:
 	docker compose exec php ./vendor/bin/php-cs-fixer fix

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -3,12 +3,6 @@
 
 	frankenphp {
 		{$FRANKENPHP_CONFIG}
-
-		worker {
-			file ./public/index.php
-			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
-			{$FRANKENPHP_WORKER_CONFIG}
-		}
 	}
 }
 

--- a/frankenphp/conf.d/20-app.dev.ini
+++ b/frankenphp/conf.d/20-app.dev.ini
@@ -3,3 +3,7 @@
 ; The `client_host` below may optionally be replaced with `discover_client_host=yes`
 ; Add `start_with_request=yes` to start debug session on each request
 xdebug.client_host = host.docker.internal
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.log=/tmp/xdebug.log
+xdebug.log_level=10


### PR DESCRIPTION
Il faut supprimer le worker de Caddyfile pour que Xdebug puisse se trigger.

Source : https://github.com/dunglas/symfony-docker/issues/782#issuecomment-2798734473